### PR TITLE
origin can be set in config-override

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ const LOGFILE_PATH = './debug.log';
 let config = {
 	defaultGrammarPath:  DEFAULT_GRAMMAR_PATH,
 	defaultGrammar: undefined,
+	origin: undefined,
 	tweetLength: TWEET_LENGTH,
 	paths: {
 		tempDirectory: TEMPFILE_PATH,

--- a/src/data/grammar.json
+++ b/src/data/grammar.json
@@ -13,10 +13,6 @@
         "#announcement#",
         "#clickbait#",
         "#flavorArcana#",
-        "#inGraphics#",
-        "#inGraphics#",
-        "#inGraphics#",
-        "#inGraphics#",
         "#inGraphics#"
     ],
     "inGraphics": [

--- a/src/news-engine.js
+++ b/src/news-engine.js
@@ -3,7 +3,10 @@
 const HeadlineMaker = require('./headline-maker');
 const config = require('../config');
 
-const headlineMaker = new HeadlineMaker(config.defaultGrammar);
+const grammar = config.defaultGrammar;
+grammar["origin"] = config.origin || grammar["origin"];
+
+const headlineMaker = new HeadlineMaker(grammar);
 
 function generateHeadlines (numHeadlines) {
 	const headlines = [];


### PR DESCRIPTION
So either a user while in development or the server while tweeting can cheat and get only results it wants.

Supports single item or array of items, just like normal `origin`.