### PR TITLE
Move wordlists around, improve pro's don't realize

### DIFF
--- a/src/data/grammar/adj.json
+++ b/src/data/grammar/adj.json
@@ -1,0 +1,19 @@
+{
+    "adj": [
+        "alarming", "amorous", "arousing", "arrogant", "avant-garde", "awful", "bad", "beloved",
+        "big", "bite-sized", "boring", "brilliant", "budget-conscious", "charming", "clammy", "collectable", "comforting",
+        "complicated", "cute", "cutting-edge", "delightful", "dreadful", "dirty", "enormous", "exciting", "fancy",
+        "fashionable", "filthy", "frightening", "funny", "garish", "genius", "gigantic", "glamorous",
+        "glorious", "good", "goofy", "groundbreaking", "hackneyed", "hamfisted", "hated", "helpless", "hilarious", "idiotic",
+        "inflamed", "inspired", "intriguing", "irrational", "laid-back", "laughable", "ludicrous",
+        "lukewarm", "madcap", "marvelous", "menacing", "mental", "miserable", "misshapen", "moist", "mundane", "mysterious",
+        "newfangled", "obvious", "oft-misunderstood", "old-fashioned", "ordinary", "outdated", "oversized", "pasty",
+        "patheitc", "pathetic", "pockmarked", "pointy", "pretentious", "provocative", "questionable", "ramshackle",
+        "refreshing", "respectable", "ridiculous", "rotten", "rough", "scaly", "scandalous", "screwball",
+        "serious", "shameful", "shocking", "sickly", "slimy", "small", "smelly", "smoking",
+        "smooth", "snow-covered", "sticky", "stinking", "sullen", "sultry", "superb", "surly",
+        "sweaty", "swollen", "tacky", "teeny-tiny", "tenacious", "tepid", "terrifying", "timeless", "tiny", "two-faced",
+        "unconventional", "unorthodox", "vainglorious", "volumetric", "well-dressed", "wonderful", "world-weary",
+        "worthless"
+    ]
+}

--- a/src/data/grammar/grammar.json
+++ b/src/data/grammar/grammar.json
@@ -42,13 +42,14 @@
         "Announcement: #pro# has joined Team #team#"
     ],
     "realization": [
+        "#realize#",
         "The Importance of [_thing:#card#,#cardCategory.s#,#creatureTypes.s#,#gameConcept#]#_thing# in [_where:#format#,#recentCardSet#]#_where#",
-        "#pros# Don't realize that #tech.s# #verbDefeat# #obstacle.capitalize#",
         "The Secret to #improvementGoal.capitalizeAll# is #deckChange.capitalize#",
         "In today's Magic Story: #character#'s #adj# history with #character# finally revealed",
         "#pro# Video Series: How I would [_change:improve,fix]#_change# Magic: the Gathering by #suggestion# #thing#, Part #num2-9#",
         "Preview of #teaserCardSet# #normalFormat#: will the new #deckVariation# deck be #deckDescription#?"
     ],
+    "realize": "#pros# don't realize that #techPlural# #verbDefeat# #obstacle#",
     "tournamentNews": [
         "Emergency Banning: #card.capitalize# Banned in #format#",
         "#card.capitalize# Banned in #format.capitalizeAll# After [winner:#deck#,#pro#]#winner.capitalizeAll# Wins #tournament.capitalizeAll#",
@@ -74,7 +75,7 @@
         "Leaked: Team #team#'s new deck #deckLocation#s #card#, invest now"
     ],
     "classifieds": [
-        "#titleClassified#: #card#",
+        "#titleClassified#: #card#, #card#, and #card#",
         "#titleClassified#: #card# playset for #priceUSD#",
         "#titleClassified#: #num2-99#x #cardAlone# @ #priceUSD# ea.",
         "#titleClassified#: #broadCardClassification.capitalizeAll# Collection for #priceUSD#",
@@ -174,6 +175,18 @@
         "rules change",
         "large set",
         "sideboard",
+        "spicy new tech"
+    ],
+    "techPlural": [
+        "#adj# decks",
+        "#adj# cards",
+        "rotating formats",
+        "rules changes",
+        "floor rulings",
+        "power-level errata",
+        "large sets",
+        "small sets",
+        "sideboards",
         "spicy new tech"
     ],
     "obstacle": [

--- a/src/data/grammar/grammar.json
+++ b/src/data/grammar/grammar.json
@@ -259,8 +259,6 @@
     "deckObjective": [
         "#deck# decks",
         "#deck# lists",
-        "#deckArch# decks",
-        "#deckArch# lists",
         "#deckArch# [_m:matchup,matchups]#_m#",
         "#cardAlone# decks",
         "#creatureTypes.capitalize# decks"

--- a/src/data/grammar/terminating-wordlists.json
+++ b/src/data/grammar/terminating-wordlists.json
@@ -1,7 +1,5 @@
 {
-  "revealVerb": ["reveal", "unveil", "disclose", "uncover", "expose", "explain"],
   "planNoun": ["plan", "scheme", "strategy", "objective", "stratagem", "tactic"],
-  "outVerb": [ "peel", "dissolve", "evaporate", "melt", "erode",  "crumble"],
   "winWord": [
       "wins","triumphs","victorious","crushes","dominates","absolutely destroys"
   ],
@@ -29,26 +27,5 @@
       "unqiue",
       "weaker",
       "stronger"
-  ],
-  "adj": [
-      "alarming", "amorous", "arousing", "arrogant", "avant-garde", "awful", "bad", "beloved",
-      "big", "bite-sized", "boring", "brilliant", "budget-conscious", "charming", "clammy", "collectable", "comforting",
-      "complicated", "cute", "cutting-edge", "delightful", "dreadful", "dirty", "enormous", "exciting", "fancy",
-      "fashionable", "filthy", "frightening", "funny", "garish", "genius", "gigantic", "glamorous",
-      "glorious", "good", "goofy", "groundbreaking", "hackneyed", "hamfisted", "hated", "helpless", "hilarious", "idiotic",
-      "inflamed", "inspired", "intriguing", "irrational", "laid-back", "laughable", "ludicrous",
-      "lukewarm", "madcap", "marvelous", "menacing", "mental", "miserable", "misshapen", "moist", "mundane", "mysterious",
-      "newfangled", "obvious", "oft-misunderstood", "old-fashioned", "ordinary", "outdated", "oversized", "pasty",
-      "patheitc", "pathetic", "pockmarked", "pointy", "pretentious", "provocative", "questionable", "ramshackle",
-      "refreshing", "respectable", "ridiculous", "rotten", "rough", "scaly", "scandalous", "screwball",
-      "serious", "shameful", "shocking", "sickly", "slimy", "small", "smelly", "smoking",
-      "smooth", "snow-covered", "sticky", "stinking", "sullen", "sultry", "superb", "surly",
-      "sweaty", "swollen", "tacky", "teeny-tiny", "tenacious", "tepid", "terrifying", "timeless", "tiny", "two-faced",
-      "unconventional", "unorthodox", "vainglorious", "volumetric", "well-dressed", "wonderful", "world-weary",
-      "worthless"
-  ],
-  "adv": [
-       "adoringly", "awkwardly", "beautifully", "cheerfully", "effortlessly", "hungrily", "intently", "quickly",
-       "recklessly", "reluctantly", "savagely", "thoughtfully", "triumphantly", "vivaciously"
   ]
 }

--- a/src/data/grammar/verbs.json
+++ b/src/data/grammar/verbs.json
@@ -22,7 +22,6 @@
       "trivializing", "renouncing", "abhoring", "disputing", "pantomiming", "advertising", "lying about", "deep-frying", "decorating", "running", "brandishing"
   ],
   "verbDefeat": [
-      "control",
       "defeat",
       "beat",
       "overcome",
@@ -31,14 +30,10 @@
       "take down"
   ],
   "verbDefeating": [
-      "controlling",
       "defeating",
       "beating",
       "overcoming",
-      "dealing with",
-      "handling",
       "becoming",
-      "truly knowing",
       "locking down",
       "fixing",
       "taking down",
@@ -50,8 +45,17 @@
       "creating",
       "brewing up",
       "developing",
-      "stewing up",
       "mashing together",
       "shuffling up"
+  ],
+  "revealVerb": [
+      "reveal", "unveil", "disclose", "uncover", "expose", "explain"
+  ],
+  "outVerb": [
+      "peel", "dissolve", "evaporate", "melt", "erode",  "crumble"
+  ],
+  "adv": [
+      "adoringly", "awkwardly", "beautifully", "cheerfully", "effortlessly", "hungrily", "intently", "quickly",
+      "recklessly", "reluctantly", "savagely", "thoughtfully", "triumphantly", "vivaciously"
   ]
 }

--- a/src/news-engine.js
+++ b/src/news-engine.js
@@ -5,6 +5,7 @@ const config = require('../config');
 
 const grammar = config.defaultGrammar;
 grammar["origin"] = config.origin || grammar["origin"];
+console.info(`New origin is ${JSON.stringify(grammar.origin)}`);
 
 const headlineMaker = new HeadlineMaker(grammar);
 


### PR DESCRIPTION
 * Forum posters don't realize that large sets overcome foils

 * MODO players don't realize that large sets take down your local draft leagues

 * Grinders don't realize that small sets take down Company

 * Facebook Commenters don't realize that rules changes beat Five-Color Rock

 * MODO players don't realize that hackneyed cards take down foils

 * Facebook Commenters don't realize that rules changes overcome discard

 * 'You Make The Card' participants don't realize that pretentious decks take down Affinity lists

 * Barns don't realize that rotating formats defeat drawing first

 * The pro's don't realize that delightful cards take down connection problems

 * Judges don't realize that power-level errata lock down walls

 * Judges don't realize that rules changes defeat flyers

 * Hall of Famers don't realize that rotating formats beat Scrubs

 * Barns don't realize that floor rulings beat instants

 * The pro's don't realize that power-level errata defeat Rumbling Slum

 * Sorcerers don't realize that rules changes defeat Barns
